### PR TITLE
Refactor document retrieval in export function

### DIFF
--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -132,8 +132,7 @@ const getDocuments = async (
   }
 
   const documentPromises: Array<Promise<object>> = [];
-  const allDocuments = await safelyGetDocumentReferences(collectionRef, logs);
-  allDocuments.forEach((doc) => {
+  documentRefs.forEach((doc) => {
 
     documentPromises.push(new Promise(async (resolve) => {
       const docSnapshot = await doc.get();


### PR DESCRIPTION
- Updated the document retrieval logic in the `getDocuments` function to use `documentRefs` instead of `allDocuments`, improving clarity and consistency in the code.
- This change enhances the readability of the document processing flow within the Firestore export functionality.

Fixes # .

Changes proposed in this pull request:
-
-
-
-

