### PR TITLE
Add projectId support for Firestore commands

### DIFF
--- a/src/bin/bin-common.ts
+++ b/src/bin/bin-common.ts
@@ -50,6 +50,12 @@ const commandLineParams: { [param: string]: Params } =
       description: `Firestore emulator host. Defaults to '${defaultFirestoreEmulatorHost}' if missing.`,
       defaultValue: defaultFirestoreEmulatorHost,
     },
+    projectId: {
+      shortKey: 'P',
+      key: 'projectId',
+      args: '<id>',
+      description: 'GCP project ID. When using the emulator with no credentials, required so the SDK uses the correct project. Falls back to GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT if not set.',
+    },
     yesToImport: {
       shortKey: 'y',
       key: 'yes',

--- a/src/bin/firestore-clear.ts
+++ b/src/bin/firestore-clear.ts
@@ -30,6 +30,7 @@ interface FirestoreClearParams {
 
   emulator: boolean;
   emulatorHost?: string;
+  projectId?: string;
 }
 
 function setupProgram(): Command {
@@ -47,6 +48,7 @@ function setupProgram(): Command {
     .option(...buildOption(params.databaseId))
     .option(...buildOption(params.emulator))
     .option(...buildOption(params.emulatorHost))
+    .option(...buildOption(params.projectId))
     .parse(process.argv);
 
   return program;
@@ -67,6 +69,10 @@ function parseParams(program: Command): FirestoreClearParams {
   const emulator = Boolean(options[params.emulator.key]);
   const emulatorHost =
     options[params.emulatorHost.key] || params.emulatorHost.defaultValue;
+  const projectId =
+    options[params.projectId.key] ||
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    process.env.GCLOUD_PROJECT;
 
   return {
     accountCredentialsPath,
@@ -76,6 +82,7 @@ function parseParams(program: Command): FirestoreClearParams {
     yesToNoWait,
     emulator,
     emulatorHost,
+    projectId,
   };
 }
 
@@ -95,6 +102,17 @@ function validateParams(commandParams: FirestoreClearParams): void {
           colors.bold(commandParams.accountCredentialsPath)
       );
     }
+  } else {
+    const hasProjectId =
+      commandParams.projectId ||
+      process.env.GOOGLE_CLOUD_PROJECT ||
+      process.env.GCLOUD_PROJECT;
+    if (!hasProjectId) {
+      throw new Error(
+        colors.bold(colors.red("When using the emulator, projectId is required. ")) +
+          "Set it via --projectId or GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT environment variable."
+      );
+    }
   }
 }
 
@@ -108,7 +126,7 @@ async function importFirestoreData(params: FirestoreClearParams) {
     process.env["FIRESTORE_EMULATOR_HOST"] = params.emulatorHost;
   }
   console.log("Getting Firestore DB Reference");
-  const db = getFirestoreDBReference(credentials, params.databaseId);
+  const db = getFirestoreDBReference(credentials, params.databaseId, params.projectId);
   console.log(`Getting DB Reference for database ${params.databaseId}`);
   const pathReference = getDBReferenceFromPath(db, params.nodePath);
   console.log(colors.bold("Reading data to import 📚"));

--- a/src/bin/firestore-export.ts
+++ b/src/bin/firestore-export.ts
@@ -31,6 +31,7 @@ interface FirestoreExportParams {
   pages?: number;
   emulator: boolean;
   emulatorHost?: string;
+  projectId?: string;
 }
 
 function setupProgram(): Command {
@@ -48,6 +49,7 @@ function setupProgram(): Command {
     .option(...buildOption(params.databaseId))
     .option(...buildOption(params.emulator))
     .option(...buildOption(params.emulatorHost))
+    .option(...buildOption(params.projectId))
     .option(...buildOption(params.limit))
     .option(...buildOption(params.startAfter))
     .option(...buildOption(params.pages))
@@ -72,6 +74,10 @@ function parseParams(program: Command): FirestoreExportParams {
   const emulator = Boolean(options[params.emulator.key]);
   const emulatorHost =
     options[params.emulatorHost.key] || params.emulatorHost.defaultValue;
+  const projectId =
+    options[params.projectId.key] ||
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    process.env.GCLOUD_PROJECT;
   const limitOpt = options[params.limit.key];
   const limit = limitOpt != null && limitOpt !== "" ? parseInt(String(limitOpt), 10) : undefined;
   const startAfter = options[params.startAfter.key] || undefined;
@@ -89,6 +95,7 @@ function parseParams(program: Command): FirestoreExportParams {
     pages: pages != null && !isNaN(pages) ? pages : undefined,
     emulator,
     emulatorHost,
+    projectId,
   };
 }
 
@@ -106,6 +113,17 @@ function validateParams(commandParams: FirestoreExportParams): void {
       throw new Error(
         colors.bold(colors.red("Account credentials file does not exist: ")) +
         colors.bold(commandParams.accountCredentialsPath)
+      );
+    }
+  } else {
+    const hasProjectId =
+      commandParams.projectId ||
+      process.env.GOOGLE_CLOUD_PROJECT ||
+      process.env.GCLOUD_PROJECT;
+    if (!hasProjectId) {
+      throw new Error(
+        colors.bold(colors.red("When using the emulator, projectId is required. ")) +
+        "Set it via --projectId or GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT environment variable."
       );
     }
   }
@@ -200,7 +218,7 @@ async function exportFirestoreData(params: FirestoreExportParams) {
     process.env["FIRESTORE_EMULATOR_HOST"] = params.emulatorHost;
   }
   console.log("Getting Firestore DB Reference");
-  const db = getFirestoreDBReference(credentials, params.databaseId);
+  const db = getFirestoreDBReference(credentials, params.databaseId, params.projectId);
   console.log(`Getting DB Reference for database ${params.databaseId}`);
   const pathReference = getDBReferenceFromPath(db, params.nodePath);
   const exportOptions: ExportOptions | undefined =

--- a/src/bin/firestore-import.ts
+++ b/src/bin/firestore-import.ts
@@ -32,6 +32,7 @@ interface FirestoreImportParams {
 
   emulator: boolean;
   emulatorHost?: string;
+  projectId?: string;
 }
 
 function setupProgram(): Command {
@@ -49,6 +50,7 @@ function setupProgram(): Command {
     .option(...buildOption(params.databaseId))
     .option(...buildOption(params.emulator))
     .option(...buildOption(params.emulatorHost))
+    .option(...buildOption(params.projectId))
     .parse(process.argv);
 
   return program;
@@ -66,6 +68,10 @@ function parseParams(program: Command): FirestoreImportParams {
   const yesToImport = Boolean(options[params.yesToImport.key]);
   const emulator = Boolean(options[params.emulator.key]);
   const emulatorHost = options[params.emulatorHost.key] || params.emulatorHost.defaultValue;
+  const projectId =
+    options[params.projectId.key] ||
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    process.env.GCLOUD_PROJECT;
 
   return {
     accountCredentialsPath,
@@ -75,6 +81,7 @@ function parseParams(program: Command): FirestoreImportParams {
     yesToImport,
     emulator,
     emulatorHost,
+    projectId,
   };
 }
 
@@ -92,6 +99,17 @@ function validateParams(commandParams: FirestoreImportParams): void {
       throw new Error(
         colors.bold(colors.red("Account credentials file does not exist: ")) +
           colors.bold(commandParams.accountCredentialsPath)
+      );
+    }
+  } else {
+    const hasProjectId =
+      commandParams.projectId ||
+      process.env.GOOGLE_CLOUD_PROJECT ||
+      process.env.GCLOUD_PROJECT;
+    if (!hasProjectId) {
+      throw new Error(
+        colors.bold(colors.red("When using the emulator, projectId is required. ")) +
+          "Set it via --projectId or GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT environment variable."
       );
     }
   }
@@ -152,7 +170,7 @@ async function importFirestoreData(params: FirestoreImportParams) {
     process.env["FIRESTORE_EMULATOR_HOST"] = params.emulatorHost;
   }
   console.log("Getting Firestore DB Reference");
-  const db = getFirestoreDBReference(credentials, params.databaseId);
+  const db = getFirestoreDBReference(credentials, params.databaseId, params.projectId);
   console.log(`Getting DB Reference for database ${params.databaseId}`);
   const pathReference = getDBReferenceFromPath(db, params.nodePath);
   console.log(colors.bold("Reading data to import 📚"));

--- a/src/lib/firestore-helpers.ts
+++ b/src/lib/firestore-helpers.ts
@@ -10,14 +10,18 @@ const getCredentialsFromFile = async (credentialsFilename: string): Promise<IFir
   return getJsonFromFile<IFirebaseCredentials>(credentialsFilename);
 };
 
-const getFirestoreDBReference = (credentials?: IFirebaseCredentials, databaseId?: string): admin.firestore.Firestore => {
+const getFirestoreDBReference = (credentials?: IFirebaseCredentials, databaseId?: string, projectId?: string): admin.firestore.Firestore => {
   if (credentials) {
     admin.initializeApp({
       credential: admin.credential.cert(credentials as any),
       databaseURL: `https://${credentials.project_id}.firebaseio.com`,
     });
   } else {
-    admin.initializeApp();
+    if (projectId) {
+      admin.initializeApp({ projectId });
+    } else {
+      admin.initializeApp();
+    }
   }
   if (databaseId) {
     return getFirestore(admin.app(), databaseId);


### PR DESCRIPTION
- Introduced a new `projectId` option in Firestore import, export, and clear scripts to specify the GCP project ID when using the emulator.
- Updated parameter validation to ensure `projectId` is provided, either through command-line options or environment variables.
- Enhanced the `getFirestoreDBReference` function to accept `projectId` for initializing the Firestore app correctly.
- Improved error handling to notify users when `projectId` is required for emulator usage.

Fixes # .

Changes proposed in this pull request:
-
-
-
-

